### PR TITLE
(fixes #3) Update docker links to wyoming-onnx-asr:v0.4.0

### DIFF
--- a/.addons.yml
+++ b/.addons.yml
@@ -4,4 +4,4 @@ addons:
   onnx-asr:
     repository: tboby/onnx-asr-addon
     target: onnx-asr
-    image: ghcr.io/tboby/onnx-asr/{arch}
+    image: ghcr.io/tboby/wyoming-onnx-asr:v0.4.0 # or pin to latest

--- a/onnx-asr/config.yaml
+++ b/onnx-asr/config.yaml
@@ -30,4 +30,4 @@ schema:
 ports:
   10300/tcp: null
 homeassistant: 2025.7.1
-image: ghcr.io/tboby/onnx-asr/{arch}
+image: ghcr.io/tboby/wyoming-onnx-asr:v0.4.0 # or just pin to latest


### PR DESCRIPTION
# Proposed Changes

- Update links to point to `wyoming-onnx-asr`
- Remove {arch} (assuming you have multi-arch builds)
- Pin to v0.4.0 instead of latest (for proper versioning)

## Related Issues

- Fixes issue [#3](https://github.com/tboby/addon-repository/issues/3)
